### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/voidlight-ritual.yml
+++ b/.github/workflows/voidlight-ritual.yml
@@ -2,6 +2,8 @@
 # 🏴‍☠️ Velvet Chains Corsair Ceremonials
 # Automated rituals to ensure our space-pirate empire maintains theatrical excellence
 name: 🏴‍☠️ Voidlight Rituals
+permissions:
+  contents: read
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/hsmalley/velvet-chains/security/code-scanning/7](https://github.com/hsmalley/velvet-chains/security/code-scanning/7)

To fix the problem, an explicit `permissions` key should be set in the workflow. The recommended approach is to set it at the top level of the workflow (immediately after `name:` and before `on:`) so that all jobs inherit the restrictive settings, unless broader permissions are specifically needed for individual jobs. Since none of the jobs (including `dco-check`) require write permissions, the minimal needed permission is typically `contents: read`, which allows GitHub Actions to check out code but not to write or modify anything in the repository via GITHUB_TOKEN. No method, import, or logic code changes are required since this is a YAML configuration change only.

**Steps:**
- Insert a block specifying `permissions: contents: read` after the `name:` key on line 4 in `.github/workflows/voidlight-ritual.yml`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
